### PR TITLE
Add inline plot support for jupyter notebooks

### DIFF
--- a/demos/cusp/cusp.ipynb
+++ b/demos/cusp/cusp.ipynb
@@ -1,0 +1,242 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "add537a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import auto"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7fdc026",
+   "metadata": {},
+   "source": [
+    " AUTO Demo cusp\n",
+    "===============\n",
+    "\n",
+    " Load the files cusp.f90 and c.cusp into the AUTO\n",
+    " command interpreter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "850a7610",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cusp = auto.load('cusp')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8473203",
+   "metadata": {},
+   "source": [
+    " Run and store the result in the Python variable mu"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "073b8d7c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mu = auto.run(cusp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2374d4b",
+   "metadata": {},
+   "source": [
+    " Run backwards, and append to mu"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5fc8cf7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mu = mu + auto.run(cusp,DS='-')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad7bca97",
+   "metadata": {},
+   "source": [
+    " Relabel solutions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "737a6812",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mu = auto.relabel(mu)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2972cbbd",
+   "metadata": {},
+   "source": [
+    " Save to b.mu, s.mu, and d.mu"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62f0c888",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto.save(mu,'mu')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "497983a9",
+   "metadata": {},
+   "source": [
+    " Plot bifurcation diagram"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "818f2093",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = auto.plot(mu)\n",
+    "p.config(bifurcation_y=['x'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "296e7d16",
+   "metadata": {},
+   "source": [
+    " Set the new start label to the first LP label in b.mu and s.mu"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ed0bb60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lp1 = auto.load(mu('LP1'), ISW=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d11083f",
+   "metadata": {},
+   "source": [
+    " Continue from this label in two parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4902f72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cusp = auto.run(lp1)\n",
+    "cusp = cusp + auto.run(lp1,DS='-')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f992ee3b",
+   "metadata": {},
+   "source": [
+    " save to b.cusp, s.cusp, and d.cusp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5d453db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auto.save(cusp,'cusp')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d4ebba2",
+   "metadata": {},
+   "source": [
+    " Plot the cusp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "355a8821",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = auto.plot(cusp)\n",
+    "p.config(bifurcation_y=['lambda'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "caf82925",
+   "metadata": {},
+   "source": [
+    "clean the directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "441921ea",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "auto.clean()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/auto/AUTOCommands.py
+++ b/python/auto/AUTOCommands.py
@@ -1770,6 +1770,8 @@ try:
         """
 
         options = kw
+        if AUTOutil.is_notebook():
+            options['hide'] = True
         if type(name) == type("") or name is None:
             name = filenameTemplate(name,templates)
             parsed = None

--- a/python/auto/AUTOutil.py
+++ b/python/auto/AUTOutil.py
@@ -487,6 +487,16 @@ def ravel(a):
 
 ArrayType = array
 
+def is_notebook():
+    """
+    test if running in jupyter notebook
+    """
+    try:
+        shell = get_ipython().__class__.__name__
+        return shell == 'ZMQInteractiveShell'
+    except NameError:
+        return False
+
 def test():
     a=array([1,2,3,4])
     print("%s"%a[::-1])

--- a/python/auto/graphics/grapher_mpl.py
+++ b/python/auto/graphics/grapher_mpl.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python
 import matplotlib
-matplotlib.use('TkAgg')
-
+from auto import AUTOutil
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 try: #MPL 2.2 wants NavigationToolbar2Tk instead
     from matplotlib.backends.backend_tkagg import NavigationToolbar2Tk as NavigationToolbar2TkAgg
 except ImportError:
     from matplotlib.backends.backend_tkagg import NavigationToolbar2TkAgg
 from matplotlib.backends.backend_agg import FigureCanvasAgg
-from matplotlib.figure import Figure
+
+if not AUTOutil.is_notebook():
+    matplotlib.use('TkAgg')
+    from matplotlib.figure import Figure
+else:
+    from matplotlib.pyplot import figure as Figure
+
 from matplotlib.lines import Line2D
 from matplotlib.axes import Axes
 from matplotlib.ticker import AutoLocator, FixedLocator
@@ -116,7 +121,7 @@ class BasicGrapher(grapher.BasicGrapher):
         self.ax2d = self.ax
         self.ax3d = None
         if kw.get("hide"):
-            self.canvas = FigureCanvasAgg(self.ax.get_figure())
+            self.canvas = self.ax.get_figure().canvas
         else:
             self.canvas = FigureCanvasTkAggRedraw(self,parent)
             tk_widget = self.canvas.get_tk_widget()


### PR DESCRIPTION
Calling auto.plot() from a jupyter notebook previously used the TkAgg backend and opened a new TkInter window. This interfered with the jupyter eventloop and made Auto difficult to use from jupyter. This patch avoids the problem, by not interfering with the matplotlib backend, if we run from within a notebook.  This results in (non-interactive) inline plots inside the browser window, similar to matplotlib figures after "%matplotlib inline". An example is given in "demos/cusp/cusp.ipynb"