### PR TITLE
Replace constants["homcont"] with constants.get("homcont")

### DIFF
--- a/python/auto/runAUTO.py
+++ b/python/auto/runAUTO.py
@@ -246,7 +246,7 @@ class runAUTO:
             os.remove("fort.2")
         if os.path.exists("fort.3"):
             os.remove("fort.3")
-        if constants["homcont"] is not None:
+        if constants.get("homcont") is not None:
             constants["homcont"].writeFilename("fort.12")
         elif os.path.exists("fort.12"):
             os.remove("fort.12")


### PR DESCRIPTION
This fixes a KeyError: 'homcont' in the following python code:

import auto
constants = auto.parseC.parseC(
    e = "cusp", unames = {1:'x'}, parnames = {1:'lambda', 2:'mu'},
    NDIM = 1, NPAR = 2, NMX = 200, NPR = 20, MXBF = 0, UZSTOP = {'mu': [-2.0, 2.0]}
)
sol0 = auto.parseS.AUTOSolution([0.0], PAR={'lambda': 1.0, 'mu': 0.0}, constants=constants) sol0.run(ICP = ['mu', 'lambda'])