### PR TITLE
Fix errant regex escapes in runAUTO.py

### DIFF
--- a/python/auto/runAUTO.py
+++ b/python/auto/runAUTO.py
@@ -115,7 +115,7 @@ class runAUTO:
         files = ["fort.7", "fort.8", "fort.9"]
         v = self.options["constants"].get("sv")
         if v is None:
-            value = re.findall("(Saved as|Appended to) \*\.(\w*)",text)
+            value = re.findall("(Saved as|Appended to) \\*\\.(\\w*)",text)
             if len(value):
                 v = value[-1][1]
         if v is not None:


### PR DESCRIPTION
any import of auto would cause warnings related to improperly escaped regexes. '\*' should be '\\*' as '\*' is not a valid python string escape. Ditto for \. and \w