### PR TITLE
Do not attempt to open the docs automatically

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -27,7 +27,6 @@ $(I)optionMenu.pdf $(I)styleMenuNew.pdf $(I)typeMenu.pdf
 all:  manual
 
 manual: auto.pdf ../plaut04/doc/userguide.pdf
-	../cmds/@mn
 
 auto.pdf:auto.tex $(FIGS) $(PLAUT04_FIGS)
 	pdflatex auto.tex


### PR DESCRIPTION
`../cmds/@mn` uses `$AUTO_DIR`, which could point to a completely different installation and if it is not set, it will attempt to open `/doc/auto.pdf` which is also wrong.
