### PR TITLE
Added missing negative sign to docs

### DIFF
--- a/doc/auto.tex
+++ b/doc/auto.tex
@@ -8642,7 +8642,7 @@ The eigenvalue problem is given by the equations
 
 \begin{equation} \begin{array}{cl}
   u_1 ' &= u_2  ,  \\
-  u_2 ' &= (p_1 \pi)^{2} u_1 , \end{array} \end{equation}
+  u_2 ' &=-(p_1 \pi)^{2} u_1 , \end{array} \end{equation}
 with boundary conditions $ u_1(0)-p_2=0 $ and $  u_1(1)=0.$
 We add the integral constraint
  $$ \int_0^{1} u_1(t)^{2} dt - p_3 = 0. $$


### PR DESCRIPTION
Added a missing negative sign in the `lin` demo which is correctly included in the implementation but had been ommitted in the documentation.

![image](https://github.com/user-attachments/assets/2d3e4404-f665-4c96-bfed-65032ae034f3)
